### PR TITLE
Fix incorrect interpretation of .gcn3 file extensions

### DIFF
--- a/src/replacements/gcn-circular/index.ts
+++ b/src/replacements/gcn-circular/index.ts
@@ -17,7 +17,7 @@ const url = `${urlOrigin}/circulars/(${circularId})`
 
 export default {
   find: new RegExp(
-    `${url}|${legacyUrl}|${preamble}${circularId}(?:${conjunction}${circularId})*`,
+    `${url}|${legacyUrl}|(?<=^|\\s)(?:${preamble}${circularId}(?:${conjunction}${circularId})*)`,
     'gi'
   ),
   replace(data, value, circularIdFromUrl, circularIdFromLegacyUrl) {

--- a/src/replacements/gcn-circular/test.html
+++ b/src/replacements/gcn-circular/test.html
@@ -5,3 +5,4 @@
 <p>And even really weird legacy URLs work: <data class="gcn-circular" value="33567">https://gcn.gsfc.nasa.gov/gcn/gcn/gcn/gcn3/33567.gcn3</data></p>
 <p>GCN Circ. <data class="gcn-circular" value="789">789</data> and GCN Circs. <data class="gcn-circular" value="3">3</data> and <data class="gcn-circular" value="4">4</data></p>
 <p>And this one refers to GCNs <data class="gcn-circular" value="1">1</data>, <data class="gcn-circular" value="23.5">23a</data>, <data class="gcn-circular" value="45.5">45.5</data> and <data class="gcn-circular" value="42">42</data></p>
+<p>This is not a Circular: http://gcn.gsfc.nasa.gov/gcn/other/971227.gcn3</p>

--- a/src/replacements/gcn-circular/test.json
+++ b/src/replacements/gcn-circular/test.json
@@ -200,6 +200,15 @@
           }
         }
       ]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "This is not a Circular: http://gcn.gsfc.nasa.gov/gcn/other/971227.gcn3"
+        }
+      ]
     }
   ]
 }

--- a/src/replacements/gcn-circular/test.md
+++ b/src/replacements/gcn-circular/test.md
@@ -11,3 +11,5 @@ And even really weird legacy URLs work: https://gcn.gsfc.nasa.gov/gcn/gcn/gcn/gc
 GCN Circ. 789 and GCN Circs. 3 and 4
 
 And this one refers to GCNs 1, 23a, 45.5 and 42
+
+This is not a Circular: http://gcn.gsfc.nasa.gov/gcn/other/971227.gcn3


### PR DESCRIPTION
Correctly interpret URLs with the file extension `.gcn3`, such as `http://gcn.gsfc.nasa.gov/gcn/other/971227.gcn3`, as a URL. Do not misinterpret the extension as a reference to GCN Circular 3.

Fixes https://github.com/nasa-gcn/gcn.nasa.gov/issues/2300.